### PR TITLE
Update trainer.py

### DIFF
--- a/training/trainer.py
+++ b/training/trainer.py
@@ -143,7 +143,7 @@ class Trainer(AbstractTrainer):
 
         self.log.update("loss_val_Deformation_ChamferL2", loss_val_Deformation_ChamferL2)
         print(
-            '\r' + colored('[%d: %d/%d]' % (self.epoch, self.iteration, self.len_dataset_test / (self.opt.batch_size)),
+            '\r' + colored('[%d: %d/%d]' % (self.epoch, self.iteration, len(self.dataloader_test)),
                            'red') +
             colored('loss_val_Deformation_ChamferL2:  %f' % loss_val_Deformation_ChamferL2.item(), 'yellow'),
             end='')


### PR DESCRIPTION
A better way to get the number of batches is len(self.dataloader_test) instead of self.len_dataset_test / (self.opt.batch_size). Also note that self.opt.batch_size is the batch size for training, not for testing which is set to 5 so it was wrong anyway.