### PR TITLE
Update correspondences.py

### DIFF
--- a/inference/correspondences.py
+++ b/inference/correspondences.py
@@ -89,8 +89,7 @@ class Inference(object):
             idx_knn = self.neigh.kneighbors(source.vertices, return_distance=False)
 
             # correspondances throught template
-            closest_points = target_reconstructed.vertices[idx_knn]
-            closest_points = np.mean(closest_points, 1, keepdims=False)
+            closest_points = target_reconstructed.vertices[idx_knn].squeeze()
 
             # project on target
             if self.project_on_target:


### PR DESCRIPTION
```
closest_points = np.mean(closest_points, 1, keepdims=False)
```
I think it can be replaced by `closest_points.squeeze()`, since the dimension of `closest_points` is (N, 1, 3) and by taking `np.mean` along the axis 1 is equivalent to just squeezing it. It will be much readable and maybe slightly faster.